### PR TITLE
[RedDwarf] Add Kamal DigitalOcean Deployment Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # website-fitness-two
+
 Chat GPT 5.5 Mode
+
+## Kamal Deployment to DigitalOcean
+
+This repository includes `config/deploy.yml` as a safe Kamal template for deploying to a DigitalOcean droplet. The file intentionally uses placeholders for every environment-specific or sensitive value; replace them locally before deploying and do not commit real credentials.
+
+Required placeholders to update:
+
+- `<APP_NAME>`: the Kamal service name for this Rails app.
+- `<DO_REGISTRY_IMAGE_NAME>`: the DigitalOcean Container Registry image name, such as `registry.digitalocean.com/<REGISTRY>/<IMAGE>`.
+- `<DROPLET_IP>`: the target DigitalOcean droplet IP address or hostname.
+- `<APP_HOSTNAME>`: the public hostname for the app.
+- `<DO_REGISTRY_USERNAME>` and `<DO_REGISTRY_PASSWORD>`: registry credentials for pushing/pulling the deployment image.
+- `<RAILS_MASTER_KEY>`: the Rails production master key or another secret-management placeholder used for `RAILS_MASTER_KEY`.
+- `<SSH_USER>`: the SSH user Kamal should use to connect to the droplet.
+
+Basic deployment flow:
+
+1. Install and configure Kamal on your workstation.
+2. Copy `config/deploy.yml` or edit it locally, replacing every `<PLACEHOLDER>` with deployment-specific values.
+3. Authenticate with DigitalOcean Container Registry using credentials that are not committed to the repository.
+4. Ensure the droplet allows SSH for `<SSH_USER>` and web traffic for `<APP_HOSTNAME>`.
+5. Run Kamal setup/deploy commands from your configured local environment.
+
+Never commit real registry passwords, droplet IPs, Rails master keys, SSH usernames, or production hostnames to this repository.

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,0 +1,38 @@
+# Kamal deployment template for DigitalOcean.
+# Replace every <PLACEHOLDER> value before deploying. Do not commit real secrets.
+
+service: <APP_NAME>
+image: <DO_REGISTRY_IMAGE_NAME>
+
+servers:
+  web:
+    - <DROPLET_IP>
+
+proxy:
+  ssl: true
+  host: <APP_HOSTNAME>
+
+registry:
+  server: registry.digitalocean.com
+  username: <DO_REGISTRY_USERNAME>
+  password: <DO_REGISTRY_PASSWORD>
+
+env:
+  clear:
+    RAILS_ENV: production
+    RAILS_SERVE_STATIC_FILES: true
+  # Keep the actual Rails secret value out of source control.
+  # Replace this placeholder locally with the production master key: <RAILS_MASTER_KEY>
+  secret:
+    - RAILS_MASTER_KEY
+
+ssh:
+  user: <SSH_USER>
+
+builder:
+  arch: amd64
+
+volumes:
+  - "<APP_NAME>_storage:/rails/storage"
+
+asset_path: /rails/public/assets


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-website-fitness-two-2-ticket-5
- Run ID: 5204c8e2-c176-49cc-94c5-1415072ca67f
- Base branch: main
- Head branch: reddwarf/derekrivers-website-fitness-two-2-ticket-5/scm
- Validation report: workspace://derekrivers-website-fitness-two-2-ticket-5-workspace/artifacts/validation-report.md

### Summary

Add `config/deploy.yml` for Kamal deployment to a DigitalOcean droplet. The file should be usable as a safe template and must not contain real secrets. Clearly mark all sensitive or environment-specific values as placeholders, including values such as `<DO_REGISTRY_PASSWORD>`, `<DROPLET_IP>`, registry image names, app hostnames, SSH user, and any Rails secret values. Align deployment documentation in the README with this configuration.

### Validation

Run deterministic lint and test checks for workspace derekrivers-website-fitness-two-2-ticket-5-workspace before review or SCM handoff.

### Acceptance Criteria

- `config/deploy.yml` exists.
- DigitalOcean droplet host/IP values are placeholders such as `<DROPLET_IP>`.
- Registry credentials and other sensitive values are placeholders such as `<DO_REGISTRY_PASSWORD>`.
- No real credentials, tokens, IPs, or secrets are committed.
- README includes Kamal deployment instructions that correspond to `config/deploy.yml`.

<!-- reddwarf:ticket_id:project:derekrivers-website-fitness-two-2:ticket:5 -->
