### PR TITLE
[RedDwarf] Add Test and RuboCop Quality Gates

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,5 @@
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :rack_test
+end

--- a/test/system/root_page_test.rb
+++ b/test/system/root_page_test.rb
@@ -1,0 +1,19 @@
+require "application_system_test_case"
+
+class RootPageTest < ApplicationSystemTestCase
+  test "root page renders all section headings" do
+    visit root_path
+
+    [
+      "Fitness that fits real life in Scotland",
+      "Personal Training",
+      "Group Classes",
+      "Nutrition Coaching",
+      "Training Videos",
+      "Client Results",
+      "Book Your FitnessFormula Session"
+    ].each do |heading|
+      assert_selector "h1,h2", text: heading
+    end
+  end
+end


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-website-fitness-two-2-ticket-3
- Run ID: dbd095ec-5bc8-42c4-9afa-d01f6decbaa2
- Base branch: main
- Head branch: reddwarf/derekrivers-website-fitness-two-2-ticket-3/scm
- Validation report: workspace://derekrivers-website-fitness-two-2-ticket-3-workspace/artifacts/validation-report.md

### Summary

Add the minimum required automated verification for the greenfield Rails app. Include a system test that visits `/` and asserts every section heading is present in the rendered HTML. Configure RuboCop with the default Rails RuboCop setup expected for a new Rails project, keeping style changes minimal and conventional.

### Validation

Run deterministic lint and test checks for workspace derekrivers-website-fitness-two-2-ticket-3-workspace before review or SCM handoff.

### Acceptance Criteria

- `bin/rails test` passes locally.
- At least one system test visits `/`.
- The system test asserts all seven section headings are present.
- `bundle exec rubocop` passes.
- RuboCop configuration uses default Rails-oriented conventions without broad disabling of checks.

<!-- reddwarf:ticket_id:project:derekrivers-website-fitness-two-2:ticket:3 -->
